### PR TITLE
Fix readme mention of dual license

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ Licensed under Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or 
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
-dual licensed as above, without any additional terms or conditions.
+licensed as above, without any additional terms or conditions.
 
   [Universal Benchmark]: https://github.com/efficient/libcuckoo/tree/master/tests/universal-benchmark


### PR DESCRIPTION
Removes a mention of a dual license from the readme since this project is currently only licensed under Apache 2.0