### PR TITLE
Update rand to 0.8 but use the SmallRng from 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,9 @@ azure-devops = { project = "jonhoo/jonhoo", pipeline = "bustle", build = "18" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-rand = { version = "0.7", features = ["small_rng"] }
+rand = { version = "0.8" }
 tracing = { version = "0.1", features = ["std"], default-features = false }
+rand_pcg = "0.3"
 
 [dev-dependencies]
 tracing-subscriber = "0.2"


### PR DESCRIPTION
The `SmallRng ` of rand changed from 0.7 to 0.8 on 64 bit machines. The new PRNG has a different seed size. This PR updates rand but keeps the old PNRG as the least invasive change.

### Alternative:
Seed with an `u64` as this is possible for all RNGs.