### PR TITLE
Make time measurement panic safe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["concurrency", "development-tools::profiling", "development-tools:
 
 [dependencies]
 rand = { version = "0.7", features = ["small_rng"] }
+scopeguard = "0.1"
 tracing = { version = "0.1", features = ["std"], default-features = false }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -442,7 +442,12 @@ fn mix<H: CollectionHandle>(
     let c = nkeys / 4 - 1;
     let find_seq_mask = nkeys - 1;
 
-    barrier.wait();
+    // The elapsed time is measured by the lifetime of `workload_scope`.
+    let workload_scope = scopeguard::guard(barrier, |barrier| {
+        barrier.wait();
+    });
+    workload_scope.wait();
+
     for (i, op) in (0..(ops / op_mix.len()))
         .flat_map(|_| op_mix.iter())
         .enumerate()
@@ -523,5 +528,4 @@ fn mix<H: CollectionHandle>(
             }
         }
     }
-    barrier.wait();
 }


### PR DESCRIPTION
Hi again,

This PR puts the std::sync::Barrier in a workload thread into a `scopeguard` to ensure that the barrier
is correctly waited under `almost` any circumstances, therefore panics in the thread won't result in the entire benchmark run hanging.

Note that this does not cover a situation where spawning a thread fails due to an OoM or the like.