### PR TITLE
Make mix function iterate through all the operations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,7 +448,7 @@ fn mix<H: CollectionHandle>(
     });
     workload_scope.wait();
 
-    for (i, op) in (0..((ops + op_mix.len() -1) / op_mix.len()))
+    for (i, op) in (0..((ops + op_mix.len() - 1) / op_mix.len()))
         .flat_map(|_| op_mix.iter())
         .enumerate()
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,7 +448,7 @@ fn mix<H: CollectionHandle>(
     });
     workload_scope.wait();
 
-    for (i, op) in (0..(ops / op_mix.len()))
+    for (i, op) in (0..((ops + op_mix.len() -1) / op_mix.len()))
         .flat_map(|_| op_mix.iter())
         .enumerate()
     {


### PR DESCRIPTION
Problem: 

Currently, the division in mix function is floor; The for loop doesn't run for all the "ops" operations.
Ex: ops = 2048 and op_mix.len() = 100. This creates a slice of length = 2000 and 48 operations are left out.

Fix:

Making the division ceil so that the for loops iterates through all operations. 
